### PR TITLE
[HAL-09] TRANSFERS ALLOWED FROM ESCROW ACCOUNT WHEN RECIPIENT'S OWNER IS THE SIGNER ALTHOUGH THE STATUS IS PAUSED

### DIFF
--- a/app/src/types/transfer_restrictions.ts
+++ b/app/src/types/transfer_restrictions.ts
@@ -28,12 +28,48 @@ export type TransferRestrictions = {
         },
         {
           name: "transferRestrictionData";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [116, 114, 100];
+              },
+              {
+                kind: "account";
+                path: "mint";
+              }
+            ];
+          };
         },
         {
           name: "securityAssociatedAccountFrom";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [115, 97, 97];
+              },
+              {
+                kind: "account";
+                path: "sourceAccount";
+              }
+            ];
+          };
         },
         {
           name: "securityAssociatedAccountTo";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [115, 97, 97];
+              },
+              {
+                kind: "account";
+                path: "destinationAccount";
+              }
+            ];
+          };
         },
         {
           name: "transferRule";

--- a/programs/tokenlock/src/instructions/cancel_timelock.rs
+++ b/programs/tokenlock/src/instructions/cancel_timelock.rs
@@ -123,7 +123,7 @@ pub fn cancel_timelock<'info>(
     enforce_transfer_restrictions_cpi(
         ctx.accounts.target_assoc.to_account_info().clone(),
         ctx.accounts.mint_address.to_account_info(),
-        ctx.accounts.reclaimer.to_account_info().to_account_info(),
+        ctx.accounts.reclaimer.to_account_info(),
         ctx.remaining_accounts[0].clone(),
         ctx.accounts
             .security_associated_account_from

--- a/programs/tokenlock/src/instructions/transfer_timelock.rs
+++ b/programs/tokenlock/src/instructions/transfer_timelock.rs
@@ -93,43 +93,41 @@ pub fn transfer_timelock<'info>(
     let timelock = timelock_account.get_timelock_mut(timelock_id).unwrap();
     let total_transfered_new = timelock.tokens_transferred.checked_add(value).unwrap();
 
-    let to = &ctx.accounts.to;
-    // if recipient owner is a signer we skip enforcing transfer restrictions
-    if ctx.accounts.authority.key() != to.owner {
-        if ctx.remaining_accounts.len() == 0
-            || ctx.remaining_accounts[0].key()
-                != TokenLockDataWrapper::transfer_restriction_data(&tokenlock_account_data)
-        {
-            return Err(TokenlockErrors::InvalidTransferRestrictionData.into());
-        }
+    if ctx.remaining_accounts.len() == 0
+        || ctx.remaining_accounts[0].key()
+            != TokenLockDataWrapper::transfer_restriction_data(&tokenlock_account_data)
+    {
+        return Err(TokenlockErrors::InvalidTransferRestrictionData.into());
+    }
 
+    {
         let authority_account_info = ctx.accounts.authority_account.clone();
         let mut account_data: &[u8] = &authority_account_info.try_borrow_data()?;
         let authority_account_data = TokenAccount::try_deserialize(&mut account_data)?;
         if authority_account_data.owner != ctx.accounts.authority.key() {
             return Err(TokenlockErrors::InvalidAccountOwner.into());
         }
+    } // free borrowed account
 
-        enforce_transfer_restrictions_cpi(
-            ctx.accounts.authority_account.clone(),
-            ctx.accounts.mint_address.to_account_info(),
-            to.to_account_info(),
-            ctx.remaining_accounts[0].clone(),
-            ctx.accounts
-                .security_associated_account_from
-                .to_account_info(),
-            ctx.accounts
-                .security_associated_account_to
-                .to_account_info(),
-            ctx.accounts.transfer_rule.to_account_info(),
-            ctx.accounts.transfer_restrictions_program.to_account_info(),
-        )?;
-    }
+    enforce_transfer_restrictions_cpi(
+        ctx.accounts.authority_account.clone(),
+        ctx.accounts.mint_address.to_account_info(),
+        ctx.accounts.to.to_account_info(),
+        ctx.remaining_accounts[0].clone(),
+        ctx.accounts
+            .security_associated_account_from
+            .to_account_info(),
+        ctx.accounts
+            .security_associated_account_to
+            .to_account_info(),
+        ctx.accounts.transfer_rule.to_account_info(),
+        ctx.accounts.transfer_restrictions_program.to_account_info(),
+    )?;
 
     transfer_spl_from_escrow(
         &ctx.accounts.token_program,
         &ctx.accounts.escrow_account.to_account_info(),
-        &to.to_account_info(),
+        &ctx.accounts.to.to_account_info(),
         &ctx.accounts.pda_account,
         value,
         &ctx.accounts.mint_address.to_account_info(),

--- a/tests/lockup-token.ts
+++ b/tests/lockup-token.ts
@@ -560,7 +560,7 @@ describe("token lockup", () => {
       investorGroupId,
       transferAdminWalletRole,
       testEnvironment.transferAdmin
-    );  
+    );
     const lockedUntil = new anchor.BN(
       await getNowTs(testEnvironment.connection)
     );

--- a/tests/tokenlock/100-timelocks.ts
+++ b/tests/tokenlock/100-timelocks.ts
@@ -305,8 +305,8 @@ describe("TokenLockup stress test", () => {
       testEnvironment.accessControlHelper.walletRolePDA(
         testEnvironment.transferAdmin.publicKey
       )[0],
-      testEnvironment.transferAdmin,
-    )
+      testEnvironment.transferAdmin
+    );
 
     const transferAmount = new anchor.BN(unlockedBalance);
     const withdrawTxSignature = await withdraw(

--- a/tests/tokenlock/100-timelocks.ts
+++ b/tests/tokenlock/100-timelocks.ts
@@ -298,6 +298,15 @@ describe("TokenLockup stress test", () => {
       authorityWalletRole,
       testEnvironment.walletsAdmin
     );
+    await testEnvironment.transferRestrictionsHelper.initializeTransferRule(
+      new anchor.BN(1),
+      group0,
+      group0,
+      testEnvironment.accessControlHelper.walletRolePDA(
+        testEnvironment.transferAdmin.publicKey
+      )[0],
+      testEnvironment.transferAdmin,
+    )
 
     const transferAmount = new anchor.BN(unlockedBalance);
     const withdrawTxSignature = await withdraw(

--- a/tests/tokenlock/locked-and-unlockedBalanceOf.ts
+++ b/tests/tokenlock/locked-and-unlockedBalanceOf.ts
@@ -609,6 +609,15 @@ describe("TokenLockup timelock balances", () => {
       authorityWalletRole,
       testEnvironment.walletsAdmin
     );
+    await testEnvironment.transferRestrictionsHelper.initializeTransferRule(
+      new anchor.BN(1),
+      group0,
+      group0,
+      testEnvironment.accessControlHelper.walletRolePDA(
+        testEnvironment.transferAdmin.publicKey
+      )[0],
+      testEnvironment.transferAdmin
+    );
 
     const balanceEscrow = (
       await testEnvironment.mintHelper.getAccount(escrowAccount)


### PR DESCRIPTION
We remove exception when lockup recipient is an target so it will enforce transfer restriction and validate pause.
The logic is the same as in EVM contract now.