### PR TITLE
[HAL-05] ANYONE COULD IMPERSONATE THE DISTRIBUTOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Typically any legal entity third-party Transfer Agent will need access to both t
 | Function                   | Contract Admin | Reserve Admin | Transfer Admin | Wallets Admin |
 | -------------------------- | -------------- | ------------- | -------------- | ------------- |
 | upgradeTransferRules()     | **yes**        | no            | no             | no            |
-| snapshot()                 | **yes**        | no            | no             | no            |
+| newDistributor()           | **yes**        | no            | **yes**        | no            |
 | mint()                     | no             | **yes**       | no             | no            |
 | burn()                     | no             | **yes**       | no             | no            |
 | forceTransferBetween()     | no             | **yes**       | no             | no            |
@@ -975,6 +975,7 @@ await program.methods
     mint: dividendsMintPubkey,
     authorityWalletRole,
     accessControl: accessControlPubkey,
+    securityMint: securityMintPubkey,
     payer: signer.publicKey,
     systemProgram: SystemProgram.programId,
   })

--- a/app/src/types/dividends.ts
+++ b/app/src/types/dividends.ts
@@ -206,6 +206,22 @@ export type Dividends = {
         {
           name: "accessControl";
           docs: ["Access Control for Security Token."];
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [97, 99];
+              },
+              {
+                kind: "account";
+                path: "securityMint";
+              }
+            ];
+          };
+        },
+        {
+          name: "securityMint";
+          writable: true;
         },
         {
           name: "payer";

--- a/deploy/dividends/new-dividends-distribution.ts
+++ b/deploy/dividends/new-dividends-distribution.ts
@@ -91,6 +91,7 @@ const deployerKeypairPath = `deploy/${options.cluster}/keys/deployer.json`;
         deployerKeypair.publicKey
       )[0],
       accessControl: accessControlHelper.accessControlPubkey,
+      securityMint: config.securityMint,
       payer: deployerKeypair.publicKey,
       systemProgram: SystemProgram.programId,
     })

--- a/programs/dividends/src/instructions/new_distributor.rs
+++ b/programs/dividends/src/instructions/new_distributor.rs
@@ -36,7 +36,7 @@ pub struct NewDistributor<'info> {
     /// Authority wallet role to create the distributor.
     #[account(
         constraint = authority_wallet_role.owner == payer.key(),
-        constraint = authority_wallet_role.has_role(access_control::Roles::ContractAdmin) @ DividendsErrorCode::Unauthorized,
+        constraint = authority_wallet_role.has_any_role(access_control::Roles::ContractAdmin as u8 | access_control::Roles::TransferAdmin as u8) @ DividendsErrorCode::Unauthorized,
         constraint = authority_wallet_role.access_control == access_control.key(),
         owner = AccessControlProgram::id(),
     )]

--- a/programs/dividends/src/instructions/new_distributor.rs
+++ b/programs/dividends/src/instructions/new_distributor.rs
@@ -1,6 +1,8 @@
-use access_control::{program::AccessControl as AccessControlProgram, AccessControl, WalletRole};
-use anchor_lang::prelude::*;
-use anchor_spl::token_interface::Mint;
+use access_control::{
+    program::AccessControl as AccessControlProgram, AccessControl, WalletRole, ACCESS_CONTROL_SEED,
+};
+use anchor_lang::{prelude::*, solana_program::program_option::COption};
+use anchor_spl::{token_2022::ID as TOKEN_2022_PROGRAM_ID, token_interface::Mint};
 
 use crate::{errors::DividendsErrorCode, MerkleDistributor, MAX_IPFS_HASH_LEN};
 
@@ -43,8 +45,22 @@ pub struct NewDistributor<'info> {
     pub authority_wallet_role: Account<'info, WalletRole>,
 
     /// Access Control for Security Token.
-    #[account(owner = AccessControlProgram::id())]
+    #[account(
+        constraint = security_mint.key() == access_control.mint,
+        seeds = [
+          ACCESS_CONTROL_SEED,
+          security_mint.key().as_ref(),
+        ],
+        bump,
+        seeds::program = AccessControlProgram::id(),
+      )]
     pub access_control: Account<'info, AccessControl>,
+
+    #[account(mut,
+        mint::token_program = TOKEN_2022_PROGRAM_ID,
+        constraint = security_mint.mint_authority == COption::Some(access_control.key()),
+    )]
+    pub security_mint: Box<InterfaceAccount<'info, Mint>>,
 
     /// Payer to create the distributor.
     #[account(mut)]

--- a/programs/dividends/src/states/merkle_distributor.rs
+++ b/programs/dividends/src/states/merkle_distributor.rs
@@ -3,8 +3,7 @@ use anchor_lang::prelude::*;
 pub const MAX_IPFS_HASH_LEN: usize = 64;
 /// State for the account which distributes tokens.
 #[account]
-#[derive(Default)]
-#[derive(InitSpace)]
+#[derive(Default, InitSpace)]
 pub struct MerkleDistributor {
     /// Base key used to generate the PDA.
     pub base: Pubkey,

--- a/tests/dividends/big-tree.ts
+++ b/tests/dividends/big-tree.ts
@@ -120,6 +120,7 @@ describe("big tree", () => {
             )[0],
           accessControl:
             testEnvironment.accessControlHelper.accessControlPubkey,
+          securityMint: testEnvironment.mintKeypair.publicKey,
           payer: signer.publicKey,
           systemProgram: SystemProgram.programId,
         })

--- a/tests/dividends/claim-dividends.ts
+++ b/tests/dividends/claim-dividends.ts
@@ -125,6 +125,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
               )[0],
             accessControl:
               testEnvironment.accessControlHelper.accessControlPubkey,
+            securityMint: testEnvironment.mintKeypair.publicKey,
             payer: signer.publicKey,
             systemProgram: SystemProgram.programId,
           })
@@ -192,6 +193,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
               )[0],
             accessControl:
               testEnvironment.accessControlHelper.accessControlPubkey,
+            securityMint: testEnvironment.mintKeypair.publicKey,
             payer: signer.publicKey,
             systemProgram: SystemProgram.programId,
           })
@@ -278,6 +280,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
               )[0],
             accessControl:
               testEnvironment.accessControlHelper.accessControlPubkey,
+            securityMint: testEnvironment.mintKeypair.publicKey,
             payer: signer.publicKey,
             systemProgram: SystemProgram.programId,
           })
@@ -384,6 +387,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
               )[0],
             accessControl:
               testEnvironment.accessControlHelper.accessControlPubkey,
+            securityMint: testEnvironment.mintKeypair.publicKey,
             payer: signer.publicKey,
             systemProgram: SystemProgram.programId,
           })
@@ -482,6 +486,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
               )[0],
             accessControl:
               testEnvironment.accessControlHelper.accessControlPubkey,
+            securityMint: testEnvironment.mintKeypair.publicKey,
             payer: signer.publicKey,
             systemProgram: SystemProgram.programId,
           })
@@ -557,6 +562,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
               )[0],
             accessControl:
               testEnvironment.accessControlHelper.accessControlPubkey,
+            securityMint: testEnvironment.mintKeypair.publicKey,
             payer: signer.publicKey,
             systemProgram: SystemProgram.programId,
           })

--- a/tests/dividends/fund-dividends.ts
+++ b/tests/dividends/fund-dividends.ts
@@ -103,6 +103,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
             )[0],
           accessControl:
             testEnvironment.accessControlHelper.accessControlPubkey,
+          securityMint: testEnvironment.mintKeypair.publicKey,
           payer: signer.publicKey,
           systemProgram: SystemProgram.programId,
         })
@@ -300,6 +301,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
             )[0],
           accessControl:
             testEnvironment.accessControlHelper.accessControlPubkey,
+          securityMint: testEnvironment.mintKeypair.publicKey,
           payer: signer.publicKey,
           systemProgram: SystemProgram.programId,
         })

--- a/tests/dividends/new-distributor.ts
+++ b/tests/dividends/new-distributor.ts
@@ -95,6 +95,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
             )[0],
           accessControl:
             testEnvironment.accessControlHelper.accessControlPubkey,
+          securityMint: testEnvironment.mintKeypair.publicKey,
           payer: signer.publicKey,
           systemProgram: SystemProgram.programId,
         })
@@ -152,6 +153,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
           authorityWalletRole: walletRole,
           accessControl:
             testEnvironment.accessControlHelper.accessControlPubkey,
+          securityMint: testEnvironment.mintKeypair.publicKey,
           payer: wallet.publicKey,
           systemProgram: SystemProgram.programId,
         })
@@ -203,6 +205,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
               )[0],
             accessControl:
               testEnvironment.accessControlHelper.accessControlPubkey,
+            securityMint: testEnvironment.mintKeypair.publicKey,
             payer: signer.publicKey,
             systemProgram: SystemProgram.programId,
           })
@@ -243,6 +246,7 @@ testCases.forEach(({ tokenProgramId, programName }) => {
             authorityWalletRole: walletRole,
             accessControl:
               testEnvironment.accessControlHelper.accessControlPubkey,
+            securityMint: testEnvironment.mintKeypair.publicKey,
             payer: wallet.publicKey,
             systemProgram: SystemProgram.programId,
           })

--- a/tests/dividends/new-distributor.ts
+++ b/tests/dividends/new-distributor.ts
@@ -20,7 +20,7 @@ type TestCase = {
 
 const testCases: TestCase[] = [
   { tokenProgramId: TOKEN_PROGRAM_ID, programName: "SPL Token" },
-  // { tokenProgramId: TOKEN_2022_PROGRAM_ID, programName: "SPL Token 2022" },
+  { tokenProgramId: TOKEN_2022_PROGRAM_ID, programName: "SPL Token 2022" },
 ];
 
 testCases.forEach(({ tokenProgramId, programName }) => {

--- a/tests/dividends/parse-balance-map.ts
+++ b/tests/dividends/parse-balance-map.ts
@@ -113,6 +113,7 @@ describe("parse BalanceMap", () => {
           signer.publicKey
         )[0],
         accessControl: testEnvironment.accessControlHelper.accessControlPubkey,
+        securityMint: testEnvironment.mintKeypair.publicKey,
         payer: signer.publicKey,
         systemProgram: SystemProgram.programId,
       })

--- a/tests/dividends/pause.ts
+++ b/tests/dividends/pause.ts
@@ -103,6 +103,7 @@ describe(`pause distribution`, () => {
           signer.publicKey
         )[0],
         accessControl: testEnvironment.accessControlHelper.accessControlPubkey,
+        securityMint: testEnvironment.mintKeypair.publicKey,
         payer: signer.publicKey,
         systemProgram: SystemProgram.programId,
       })


### PR DESCRIPTION
Now we validate that `access_control` account is derived from security mint account. So only original access control can be provided together with original security mint