### PR TITLE
[HAL-01] PAUSED STATUS CHECK MISSING IN PAUSE INSTRUCTIONS

### DIFF
--- a/app/src/idls/access_control.json
+++ b/app/src/idls/access_control.json
@@ -1202,7 +1202,7 @@
     },
     {
       "code": 6004,
-      "name": "MisMatchedEscrow",
+      "name": "MismatchedEscrowAccount",
       "msg": "Mismatched escrow account"
     },
     {
@@ -1214,6 +1214,11 @@
       "code": 6006,
       "name": "CantForceTransferBetweenLockup",
       "msg": "Cannot force transfer between lockup accounts"
+    },
+    {
+      "code": 6007,
+      "name": "ValueUnchanged",
+      "msg": "The provided value is already set. No changes were made"
     }
   ],
   "types": [

--- a/app/src/idls/dividends.json
+++ b/app/src/idls/dividends.json
@@ -283,7 +283,26 @@
           "name": "access_control",
           "docs": [
             "Access Control for Security Token."
-          ]
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  99
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "security_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "security_mint",
+          "writable": true
         },
         {
           "name": "payer",
@@ -518,6 +537,11 @@
       "code": 6010,
       "name": "InvalidIPFSHashSize",
       "msg": "Invalid IPFS hash size"
+    },
+    {
+      "code": 6011,
+      "name": "ValueUnchanged",
+      "msg": "The provided value is already set. No changes were made"
     }
   ],
   "types": [

--- a/app/src/idls/transfer_restrictions.json
+++ b/app/src/idls/transfer_restrictions.json
@@ -30,13 +30,61 @@
           "name": "destination_account"
         },
         {
-          "name": "transfer_restriction_data"
+          "name": "transfer_restriction_data",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  114,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
         },
         {
-          "name": "security_associated_account_from"
+          "name": "security_associated_account_from",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  97,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "source_account"
+              }
+            ]
+          }
         },
         {
-          "name": "security_associated_account_to"
+          "name": "security_associated_account_to",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  97,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "destination_account"
+              }
+            ]
+          }
         },
         {
           "name": "transfer_rule",
@@ -2054,6 +2102,11 @@
       "code": 6020,
       "name": "ZeroGroupHolderGroupMaxCannotBeNonZero",
       "msg": "Zero group holder group max cannot be non-zero"
+    },
+    {
+      "code": 6021,
+      "name": "ValueUnchanged",
+      "msg": "The provided value is already set. No changes were made"
     }
   ],
   "types": [

--- a/app/src/types/access_control.ts
+++ b/app/src/types/access_control.ts
@@ -974,6 +974,11 @@ export type AccessControl = {
       code: 6006;
       name: "cantForceTransferBetweenLockup";
       msg: "Cannot force transfer between lockup accounts";
+    },
+    {
+      code: 6007;
+      name: "valueUnchanged";
+      msg: "The provided value is already set. No changes were made";
     }
   ];
   types: [

--- a/app/src/types/dividends.ts
+++ b/app/src/types/dividends.ts
@@ -376,6 +376,11 @@ export type Dividends = {
       code: 6010;
       name: "invalidIpfsHashSize";
       msg: "Invalid IPFS hash size";
+    },
+    {
+      code: 6011;
+      name: "valueUnchanged";
+      msg: "The provided value is already set. No changes were made";
     }
   ];
   types: [

--- a/app/src/types/transfer_restrictions.ts
+++ b/app/src/types/transfer_restrictions.ts
@@ -1706,6 +1706,11 @@ export type TransferRestrictions = {
       code: 6020;
       name: "zeroGroupHolderGroupMaxCannotBeNonZero";
       msg: "Zero group holder group max cannot be non-zero";
+    },
+    {
+      code: 6021;
+      name: "valueUnchanged";
+      msg: "The provided value is already set. No changes were made";
     }
   ];
   types: [

--- a/programs/access-control/src/errors.rs
+++ b/programs/access-control/src/errors.rs
@@ -16,4 +16,6 @@ pub enum AccessControlError {
     CantBurnSecuritiesWithinLockup,
     #[msg("Cannot force transfer between lockup accounts")]
     CantForceTransferBetweenLockup,
+    #[msg("The provided value is already set. No changes were made")]
+    ValueUnchanged,
 }

--- a/programs/access-control/src/instructions/access_control/set_lockup_escrow_account.rs
+++ b/programs/access-control/src/instructions/access_control/set_lockup_escrow_account.rs
@@ -11,6 +11,11 @@ pub fn set_lockup_escrow_account(ctx: Context<SetLockupEscrowAccount>) -> Result
     {
         return Err(AccessControlError::Unauthorized.into());
     }
+    if ctx.accounts.access_control_account.lockup_escrow_account
+        == Some(ctx.accounts.escrow_account.key())
+    {
+        return Err(AccessControlError::ValueUnchanged.into());
+    }
 
     let discriminator = TokenLockData::discriminator();
     let tokenlock_account = &ctx.accounts.tokenlock_account;

--- a/programs/access-control/src/instructions/access_control/update_wallet_role.rs
+++ b/programs/access-control/src/instructions/access_control/update_wallet_role.rs
@@ -12,6 +12,9 @@ pub fn update_wallet_role(ctx: Context<UpdateWalletRole>, role: u8) -> Result<()
     if role > Roles::All as u8 {
         return Err(AccessControlError::InvalidRole.into());
     }
+    if role == ctx.accounts.wallet_role.role {
+        return Err(AccessControlError::ValueUnchanged.into());
+    }
 
     let wallet_role = &mut ctx.accounts.wallet_role;
     wallet_role.role = role;

--- a/programs/dividends/src/errors.rs
+++ b/programs/dividends/src/errors.rs
@@ -24,4 +24,6 @@ pub enum DividendsErrorCode {
     DistributorNotReadyToClaim,
     #[msg("Invalid IPFS hash size")]
     InvalidIPFSHashSize,
+    #[msg("The provided value is already set. No changes were made")]
+    ValueUnchanged,
 }

--- a/programs/dividends/src/instructions/pause.rs
+++ b/programs/dividends/src/instructions/pause.rs
@@ -13,7 +13,7 @@ pub struct Pause<'info> {
 
     /// Authority wallet role to pause the distributor.
     #[account(
-      constraint = authority_wallet_role.owner == authority.key(),
+        constraint = authority_wallet_role.owner == authority.key(),
         constraint = authority_wallet_role.has_role(access_control::Roles::ContractAdmin) @ DividendsErrorCode::Unauthorized,
         constraint = authority_wallet_role.access_control == access_control.key(),
     )]
@@ -29,6 +29,10 @@ pub struct Pause<'info> {
 }
 
 pub fn pause(ctx: Context<Pause>, paused: bool) -> Result<()> {
+    if paused == ctx.accounts.distributor.paused {
+        return Err(DividendsErrorCode::ValueUnchanged.into());
+    }
+
     let distributor = &mut ctx.accounts.distributor;
     distributor.paused = paused;
 

--- a/programs/transfer-restrictions/src/errors.rs
+++ b/programs/transfer-restrictions/src/errors.rs
@@ -44,4 +44,6 @@ pub enum TransferRestrictionsError {
     NewHolderGroupMaxMustExceedCurrentHolderGroupCount,
     #[msg("Zero group holder group max cannot be non-zero")]
     ZeroGroupHolderGroupMaxCannotBeNonZero,
+    #[msg("The provided value is already set. No changes were made")]
+    ValueUnchanged,
 }

--- a/programs/transfer-restrictions/src/instructions/transfer_restrictions/pause.rs
+++ b/programs/transfer-restrictions/src/instructions/transfer_restrictions/pause.rs
@@ -10,6 +10,9 @@ pub fn pause(ctx: Context<Pause>, paused: bool) -> Result<()> {
     {
         return Err(TransferRestrictionsError::Unauthorized.into());
     }
+    if paused == ctx.accounts.transfer_restriction_data.paused {
+        return Err(TransferRestrictionsError::ValueUnchanged.into());
+    }
 
     let transfer_restriction_data = &mut ctx.accounts.transfer_restriction_data;
     transfer_restriction_data.paused = paused;

--- a/programs/transfer-restrictions/src/instructions/transfer_restrictions/set_allow_transfer_rule.rs
+++ b/programs/transfer-restrictions/src/instructions/transfer_restrictions/set_allow_transfer_rule.rs
@@ -10,6 +10,9 @@ pub fn set_allow_transfer_rule(
     if !ctx.accounts.authority_wallet_role.has_role(Roles::TransferAdmin) {
         return Err(TransferRestrictionsError::Unauthorized.into());
     }
+    if ctx.accounts.transfer_rule.locked_until == locked_until {
+        return Err(TransferRestrictionsError::ValueUnchanged.into());
+    }
 
     let transfer_rule = &mut ctx.accounts.transfer_rule;
     transfer_rule.locked_until = locked_until;

--- a/programs/transfer-restrictions/src/instructions/transfer_restrictions/set_holder_group_max.rs
+++ b/programs/transfer-restrictions/src/instructions/transfer_restrictions/set_holder_group_max.rs
@@ -13,6 +13,10 @@ pub fn set_holder_group_max(
 
     let group = &mut ctx.accounts.group;
     require!(
+        group.max_holders != holder_max,
+        TransferRestrictionsError::ValueUnchanged
+    );
+    require!(
         group.id != 0,
         TransferRestrictionsError::ZeroGroupHolderGroupMaxCannotBeNonZero
     );

--- a/programs/transfer-restrictions/src/instructions/transfer_restrictions/set_holder_max.rs
+++ b/programs/transfer-restrictions/src/instructions/transfer_restrictions/set_holder_max.rs
@@ -12,6 +12,10 @@ pub fn set_holder_max(
     }
     let transfer_restriction_data = &mut ctx.accounts.transfer_restriction_data;
     require!(
+        transfer_restriction_data.max_holders != holder_max,
+        TransferRestrictionsError::ValueUnchanged
+    );
+    require!(
         holder_max >= transfer_restriction_data.current_holders_count,
         TransferRestrictionsError::NewHolderMaxMustExceedCurrentHolderCount
     );

--- a/tests/access_control/set-lockup-escrow-account.ts
+++ b/tests/access_control/set-lockup-escrow-account.ts
@@ -204,4 +204,22 @@ describe("Set lockup escrow account", () => {
       await testEnvironment.accessControlHelper.accessControlData();
     assert.equal(lockupEscrowAccountAfter.toString(), escrowAccount.toString());
   });
+
+  it("fails to set lockup escrow account when it is already set", async () => {
+    const signer = testEnvironment.contractAdmin;
+    try {
+      await testEnvironment.accessControlHelper.setLockupEscrowAccount(
+        escrowAccount,
+        tokenlockDataPubkey,
+        signer
+      );
+      assert.fail("Expect an error");
+    } catch ({ error }) {
+      assert.equal(error.errorCode.code, "ValueUnchanged");
+      assert.equal(
+        error.errorMessage,
+        "The provided value is already set. No changes were made"
+      );
+    }
+  });
 });

--- a/tests/access_control/wallet-role.ts
+++ b/tests/access_control/wallet-role.ts
@@ -194,4 +194,21 @@ describe("Access Control wallet role", () => {
       assert.equal(error.errorMessage, "Invalid role");
     }
   });
+
+  it("fails to update wallet role to the same role", async () => {
+    try {
+      await testEnvironment.accessControlHelper.updateWalletRole(
+        investor.publicKey,
+        Roles.TransferAdmin,
+        testEnvironment.contractAdmin
+      );
+      assert.fail("Expected an error");
+    } catch ({ error }) {
+      assert.equal(error.errorCode.code, "ValueUnchanged");
+      assert.equal(
+        error.errorMessage,
+        "The provided value is already set. No changes were made"
+      );
+    }
+  });
 });

--- a/tests/dividends/pause.ts
+++ b/tests/dividends/pause.ts
@@ -223,4 +223,43 @@ describe(`pause distribution`, () => {
     );
     assert.equal(distributorData.paused, false);
   });
+
+  it("fails to pause when already paused", async () => {
+    await dividendsProgram.methods
+      .pause(true)
+      .accountsStrict({
+        distributor,
+        accessControl: testEnvironment.accessControlHelper.accessControlPubkey,
+        authorityWalletRole: testEnvironment.accessControlHelper.walletRolePDA(
+          signer.publicKey
+        )[0],
+        authority: signer.publicKey,
+      })
+      .signers([signer])
+      .rpc({ commitment });
+
+    try {
+      await dividendsProgram.methods
+        .pause(true)
+        .accountsStrict({
+          distributor,
+          accessControl:
+            testEnvironment.accessControlHelper.accessControlPubkey,
+          authorityWalletRole:
+            testEnvironment.accessControlHelper.walletRolePDA(
+              signer.publicKey
+            )[0],
+          authority: signer.publicKey,
+        })
+        .signers([signer])
+        .rpc({ commitment });
+      assert.fail("Expected an error");
+    } catch ({ error }) {
+      assert.equal(error.errorCode.code, "ValueUnchanged");
+      assert.equal(
+        error.errorMessage,
+        "The provided value is already set. No changes were made"
+      );
+    }
+  });
 });

--- a/tests/transfer_restrictions/pause.ts
+++ b/tests/transfer_restrictions/pause.ts
@@ -399,4 +399,34 @@ describe("Pause transfers", () => {
       (reserveAmountBeforeTransfer + BigInt(transferAmount)).toString()
     );
   });
+
+  it("fails to pause with the same value as it is on-chain", async () => {
+    const signer = testEnvironment.transferAdmin;
+    const [authorityWalletRolePubkey] =
+      testEnvironment.accessControlHelper.walletRolePDA(signer.publicKey);
+
+    try {
+      await testEnvironment.transferRestrictionsHelper.program.methods
+        .pause(false)
+        .accountsStrict({
+          securityMint: testEnvironment.mintKeypair.publicKey,
+          transferRestrictionData:
+            testEnvironment.transferRestrictionsHelper
+              .transferRestrictionDataPubkey,
+          accessControlAccount:
+            testEnvironment.accessControlHelper.accessControlPubkey,
+          authorityWalletRole: authorityWalletRolePubkey,
+          payer: signer.publicKey,
+        })
+        .signers([signer])
+        .rpc({ commitment: testEnvironment.commitment });
+      assert.fail("Expect an error");
+    } catch ({ error }) {
+      assert.equal(error.errorCode.code, "ValueUnchanged");
+      assert.equal(
+        error.errorMessage,
+        "The provided value is already set. No changes were made"
+      );
+    }
+  });
 });


### PR DESCRIPTION
Validation is added to next instructions: 
1. pause (`access-control` and `transfer-restrictions`)
2. set_lockup_escrow_account (`access-control`)
3. update_wallet_role
4. set_allow_transfer_rule
5. set_holder_group_max
6. set_holder_max